### PR TITLE
refactor: extract Jackson config, simplify Redis session, fix Swagger versions and Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Build output
+target/
+
+# IDE
+.idea/
+*.iml
+.vscode/
+.settings/
+.project
+.classpath
+
+# Git
+.git/
+.gitignore
+.github/
+
+# Docker (don't let changes to these trigger a source rebuild)
+Dockerfile
+DockerfileForAOTCache
+DockerfileForProjectCRaC
+docker-compose.yml
+
+# Docs & scripts (not needed for Maven build)
+docs/
+tmp/
+*.md
+appmap.yml
+
+# Runtime files (not needed at build time)
+keys/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,96 @@
-FROM openjdk:25-rc-jdk-slim
-ARG JAR_FILE=target/*.jar
-COPY ${JAR_FILE} oauth2-authorization-server.jar
-ENTRYPOINT ["java","-jar","/oauth2-authorization-server.jar"]
+# ─────────────────────────────────────────────────────────────────────────────
+# Multi-stage Dockerfile for oauth2-authorization-server
+# Produces a minimal image using jlink custom JRE (~50% smaller than full JDK)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Stage 1: Build ───────────────────────────────────────────────────────────
+FROM maven:4.0.0-rc-5-ibm-semeru-25-noble AS build
+
+WORKDIR /app
+
+# Copy pom.xml first and resolve dependencies (layer caching)
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 mvn dependency:go-offline -B -q || true
+
+# Copy entire project context so ANY file change invalidates the build cache.
+# Non-build files (docs, keys, IDE config, etc.) are excluded via .dockerignore.
+COPY . .
+RUN --mount=type=cache,target=/root/.m2 mvn clean package -DskipTests -q
+
+# ── Stage 2: Custom JRE via jlink ────────────────────────────────────────────
+# Create a minimal Java runtime with only the modules the application needs.
+# Modules:
+#   java.base              – core (always included)
+#   java.sql               – JDBC (MariaDB, Oracle)
+#   java.naming            – JNDI (Spring datasource lookup, LDAP)
+#   java.net.http          – RestClient / HTTP client
+#   java.xml               – Spring / Thymeleaf XML processing
+#   java.desktop           – AWT dependencies pulled by some libraries
+#   java.management        – JMX (Actuator, Micrometer)
+#   jdk.management         – platform MXBeans (Actuator /health, /metrics)
+#   java.instrument        – Spring agent / ByteBuddy
+#   java.security.jgss     – Kerberos / GSSAPI (LDAP, broker auth)
+#   java.security.sasl     – SASL authentication
+#   jdk.crypto.ec          – TLS with EC algorithms
+#   java.compiler          – javax.lang.model.SourceVersion
+#   java.logging           – JUL bridge for Logback
+#   java.transaction.xa    – JTA (JPA / Hibernate)
+#   jdk.unsupported        – sun.misc.Unsafe (Netty, gRPC, serialisation)
+#   jdk.net                – extended socket options (Netty epoll)
+FROM build AS jre-builder
+
+RUN "$JAVA_HOME"/bin/jlink \
+      --add-modules java.base,java.sql,java.naming,java.net.http,java.xml,\
+java.desktop,java.management,jdk.management,java.instrument,\
+java.security.jgss,java.security.sasl,jdk.crypto.ec,java.compiler,\
+java.logging,java.transaction.xa,jdk.unsupported,jdk.net \
+      --strip-java-debug-attributes \
+      --no-man-pages \
+      --no-header-files \
+      --compress=zip-6 \
+      --output /javaruntime
+
+# Strip debug symbols from native libs
+RUN find /javaruntime -name '*.so' -exec strip --strip-unneeded {} + 2>/dev/null || true
+
+# ── Stage 3: Extract Spring Boot layers ──────────────────────────────────────
+FROM build AS extractor
+
+WORKDIR /extract
+COPY --from=build /app/target/*.jar app.jar
+RUN java -Djarmode=tools -jar app.jar extract --layers --destination extracted
+
+# ── Stage 4: Final runtime image ─────────────────────────────────────────────
+FROM debian:bookworm-slim
+
+# Security: run as non-root
+RUN groupadd --system appgroup && useradd --system --gid appgroup appuser
+
+ENV JAVA_HOME=/opt/java/jdk25
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+WORKDIR /app
+
+# Copy custom JRE
+COPY --from=jre-builder /javaruntime ${JAVA_HOME}
+
+# Copy extracted layers (best Docker cache utilisation)
+COPY --from=extractor /extract/extracted/dependencies/          ./
+COPY --from=extractor /extract/extracted/spring-boot-loader/    ./
+COPY --from=extractor /extract/extracted/snapshot-dependencies/ ./
+COPY --from=extractor /extract/extracted/application/           ./
+
+# Create directory for JWT RSA key persistence
+RUN mkdir -p /app/keys && chown appuser:appgroup /app/keys
+
+# Switch to non-root user
+USER appuser
+
+EXPOSE 9000
+
+# --enable-native-access=ALL-UNNAMED: Java 25 requires explicit permission
+# for libraries accessing native code (Netty, Jedis, gRPC, Redisson, etc.)
+ENTRYPOINT ["java", \
+  "--enable-native-access=ALL-UNNAMED", \
+  "-Djava.security.egd=file:/dev/./urandom", \
+  "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -16,9 +16,22 @@
         export ANTHROPIC_API_KEY=your_api_key_here      # Optional
         export GOOGLE_GENAI_API_KEY=your_api_key_here   # Optional
         ```
-- Run `docker-compose up -d` command to run necessary services
-- Run `mvn test` or `mvn clean install` or `mvn clean package` or `./mvnw clean install` command to run all the tests
-- Run `mvn spring-boot:run` command to run the application
+- ```bash
+    cd oauth2-authorization-server
+    
+    # Run tests on the host (requires Docker for Testcontainers)
+    mvn clean verify
+    
+    # Build and start the application together with all infrastructure services
+    docker compose --profile start_application up -d --build
+    
+    # Start only infrastructure services (Redis, MariaDB, LDAP, Ollama, etc.)
+    docker compose up -d
+    
+    # For local development without Docker (requires infrastructure services running via docker compose up -d)
+    ./mvnw spring-boot:run   # or: mvn spring-boot:run
+  ```
+
 - Import the followings to test in Postman
     - [OAuth2 Authorization Server.postman_collection.json](docs/postman/OAuth2%20Authorization%20Server.postman_collection.json)
     - [OAuth2 Authorization Server.postman_environment.json](docs/postman/OAuth2%20Authorization%20Server.postman_environment.json)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,36 @@
 services:
+
+  # ── Application (only with: docker compose --profile start_application up -d --build) ──
+  oauth2-authorization-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: oauth2-authorization-server
+    profiles:
+      - start_application
+    ports:
+      - "9000:9000"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mariadb://mariadb:3306/oauth2_authorization_server
+      DB_USERNAME: mb_test
+      DB_PASSWORD: 'test'
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
+      SPRING_LDAP_URL: ldap://lldap:3890
+      MINIO_ENDPOINT: http://minio:9000
+      ZIPKIN_ENDPOINT: http://zipkin:9411/api/v2/spans
+      OTEL_EXPORTER_OTLP_METRICS_URL: http://grafana-lgtm:4318/v1/metrics
+      OTEL_EXPORTER_OTLP_TRACES_URL: http://grafana-lgtm:4318/v1/traces
+      OTEL_EXPORTER_OTLP_LOGS_URL: http://grafana-lgtm:4318/v1/logs
+    depends_on:
+      - mariadb
+      - redis
+      - lldap
+    restart: unless-stopped
+    networks:
+      - oauth2-network
+
+  # ── Infrastructure services (always started with: docker compose up -d) ──────
   mariadb:
     image: mariadb:12.1.2
     container_name: mariadb
@@ -95,12 +127,16 @@ services:
       - "9091:9000"
       - "9001:9001"
     command: server /data --console-address :9001
+    networks:
+      - oauth2-network
 
   zipkin:
     image: openzipkin/zipkin:3
     container_name: zipkin
     ports:
       - "9411:9411"
+    networks:
+      - oauth2-network
 
   grafana-lgtm:
     image: 'grafana/otel-lgtm:0.13.0'
@@ -110,6 +146,8 @@ services:
       - "4317:4317"   # OTLP gRPC receiver
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
+    networks:
+      - oauth2-network
 
 volumes:
   ollama: { }

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <java.version>25</java.version>
-        <spring-ai.version>2.0.0-M1</spring-ai.version>
+        <spring-ai.version>2.0.0-M4</spring-ai.version>
         <thymeleaf-extras-springsecurity6.version>3.1.3.RELEASE</thymeleaf-extras-springsecurity6.version>
         <mariadb-java-client.version>3.5.7</mariadb-java-client.version>
         <ojdbc17.version>23.26.1.0.0</ojdbc17.version>
@@ -25,6 +25,7 @@
         <taikai.version>1.60.0</taikai.version>
         <instancio-junit.version>6.0.0-RC1</instancio-junit.version>
         <springdoc-openapi-starter-webmvc-ui.version>3.0.2</springdoc-openapi-starter-webmvc-ui.version>
+        <swagger-openapiv3.version>2.2.47</swagger-openapiv3.version>
         <spring-boot-thin-layout.version>1.0.31.RELEASE</spring-boot-thin-layout.version>
         <org.mapstruct.version>1.7.0.Beta1</org.mapstruct.version>
         <opentelemetry-logback-appender-1.0.version>2.25.0-alpha</opentelemetry-logback-appender-1.0.version>
@@ -347,6 +348,27 @@
             <version>${springdoc-openapi-starter-webmvc-ui.version}</version>
         </dependency>
 
+        <!-- Align all Swagger artifacts to the same version (springdoc 3.0.2 pulls mismatched versions) -->
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-core-jakarta</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-models-jakarta</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations-jakarta</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
@@ -485,6 +507,14 @@
                 <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-bom</artifactId>
+                <version>${swagger-openapiv3.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/mb/oauth2authorizationserver/OAuth2AuthorizationServerApplication.java
+++ b/src/main/java/mb/oauth2authorizationserver/OAuth2AuthorizationServerApplication.java
@@ -9,14 +9,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisIndexedHttpSession;
 
 import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 @Slf4j
 @EnableAsync
 @SpringBootApplication
-@EnableRedisIndexedHttpSession
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class OAuth2AuthorizationServerApplication {
 

--- a/src/main/java/mb/oauth2authorizationserver/api/controller/UserController.java
+++ b/src/main/java/mb/oauth2authorizationserver/api/controller/UserController.java
@@ -2,7 +2,15 @@ package mb.oauth2authorizationserver.api.controller;
 
 import io.micrometer.observation.annotation.Observed;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mb.oauth2authorizationserver.api.request.ApiUserRequest;
@@ -27,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/users")
 @SecurityRequirement(name = "security_auth")
+@Tag(name = "User Management", description = "CRUD operations for user management")
 public class UserController {
 
     private final UserService userService;
@@ -34,40 +43,106 @@ public class UserController {
 
     @GetMapping("/")
     @Observed(name = "getUsers")
-    @Operation(description = "Get all users.")
-    public ResponseEntity<Page<ApiUserResponse>> getUsers(Pageable pageable) {
+    @Operation(summary = "Get all users", description = "Retrieves a paginated list of all users.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Users retrieved successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = Page.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @Parameter(name = "size", description = "Page size", example = "20", in = ParameterIn.QUERY)
+    @Parameter(name = "page", description = "Page number (0-based)", example = "0", in = ParameterIn.QUERY)
+    @Parameter(name = "sort", description = "Sort criteria (e.g. firstName,asc)", example = "firstName,asc", in = ParameterIn.QUERY)
+    public ResponseEntity<Page<ApiUserResponse>> getUsers(@Parameter(hidden = true) Pageable pageable) {
         log.info("Received a request to get all users. getAllUsers.");
         return new ResponseEntity<>(userMapper.map(userService.getAllUsers(pageable)), HttpStatus.OK);
     }
 
     @PostMapping("/")
     @Observed(name = "createUser")
-    @Operation(description = "Create user.")
-    public ResponseEntity<ApiUserResponse> createUser(@RequestBody ApiUserRequest apiUserRequest) {
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "User created successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiUserResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Invalid request body"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @Operation(summary = "Create user", description = "Creates a new user with the provided details.")
+    public ResponseEntity<ApiUserResponse> createUser(@Valid @RequestBody ApiUserRequest apiUserRequest) {
         log.info("Received a request to create user. createUser - apiUserRequest: {}", apiUserRequest);
         return new ResponseEntity<>(userMapper.map(userService.createUser(userMapper.map(apiUserRequest))), HttpStatus.CREATED);
     }
 
     @GetMapping("/{userId}")
     @Observed(name = "getUserById")
-    @Operation(description = "Get user by id.")
-    public ResponseEntity<ApiUserResponse> getUserById(@PathVariable Long userId) {
+    @Operation(summary = "Get user by id", description = "Retrieves a user by their unique identifier.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "User retrieved successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiUserResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "404", description = "User not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public ResponseEntity<ApiUserResponse> getUserById(@Parameter(description = "User id", example = "1") @PathVariable Long userId) {
         log.info("Received a request to get user by id. getUserById - userId: {}", userId);
         return new ResponseEntity<>(userMapper.map(userService.getUserById(userId)), HttpStatus.OK);
     }
 
     @PutMapping("/{userId}")
     @Observed(name = "updateUserById")
-    @Operation(description = "Update user.")
-    public ResponseEntity<ApiUserResponse> updateUserById(@PathVariable Long userId, @RequestBody ApiUserRequest apiUserRequest) {
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "User updated successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiUserResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "Invalid request body"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "404", description = "User not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @Operation(summary = "Update user", description = "Updates an existing user by their unique identifier.")
+    public ResponseEntity<ApiUserResponse> updateUserById(@Parameter(description = "User id", example = "1") @PathVariable Long userId,
+                                                          @RequestBody ApiUserRequest apiUserRequest) {
         log.info("Received a request to update user by id. updateUserById - userId: {}, apiUserRequest: {}", userId, apiUserRequest);
         return new ResponseEntity<>(userMapper.map(userService.updateUserById(userMapper.map(userService.getUserById(userId), userMapper.map(apiUserRequest)))), HttpStatus.OK);
     }
 
     @DeleteMapping("/{userId}")
     @Observed(name = "deleteUserById")
-    @Operation(description = "Delete user by id.")
-    public ResponseEntity<String> deleteUserById(@PathVariable Long userId) {
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "User deleted successfully",
+                    content = @Content(mediaType = "text/plain")
+            ),
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "404", description = "User not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @Operation(summary = "Delete user by id", description = "Deletes a user by their unique identifier.")
+    public ResponseEntity<String> deleteUserById(@Parameter(description = "User id", example = "1") @PathVariable Long userId) {
         log.info("Received a request to delete user by id. deleteUserById - userId: {}", userId);
         userService.deleteUserById(userId);
         return new ResponseEntity<>("User deleted successfully.", HttpStatus.OK);

--- a/src/main/java/mb/oauth2authorizationserver/api/controller/ai/AnthropicController.java
+++ b/src/main/java/mb/oauth2authorizationserver/api/controller/ai/AnthropicController.java
@@ -1,14 +1,20 @@
 package mb.oauth2authorizationserver.api.controller.ai;
 
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.core.http.HttpResponse;
+import com.anthropic.models.beta.files.FileMetadata;
+import com.anthropic.models.beta.files.FileRetrieveMetadataParams;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.anthropic.AnthropicChatModel;
 import org.springframework.ai.anthropic.AnthropicChatOptions;
+import org.springframework.ai.anthropic.AnthropicCitationDocument;
+import org.springframework.ai.anthropic.AnthropicSkill;
+import org.springframework.ai.anthropic.AnthropicSkillsResponseHelper;
 import org.springframework.ai.anthropic.Citation;
-import org.springframework.ai.anthropic.SkillsResponseHelper;
-import org.springframework.ai.anthropic.api.AnthropicApi;
-import org.springframework.ai.anthropic.api.CitationDocument;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.http.HttpHeaders;
@@ -21,7 +27,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * NEW IN SPRING AI 2.0: Anthropic Claude Advanced Features
@@ -35,12 +43,12 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/anthropic")
-@ConditionalOnBean(name = "anthropicChatClient")
+@ConditionalOnBean(name = {"anthropicChatClient", "anthropicClient"})
 public class AnthropicController {
 
     private final AnthropicChatModel chatModel;
     private final ChatClient anthropicChatClient;
-    private final AnthropicApi anthropicApi;
+    private final AnthropicClient anthropicClient; // official SDK bean, replaces AnthropicApi
 
     /**
      * NEW IN 2.0: Citations API - Claude references specific parts of your document.
@@ -48,7 +56,7 @@ public class AnthropicController {
      */
     @PostMapping("/citations")
     public CitationsResponse citations(@RequestBody CitationRequest request) {
-        CitationDocument document = CitationDocument.builder()
+        AnthropicCitationDocument document = AnthropicCitationDocument.builder()
                 .plainText(request.document())
                 .title(request.title())
                 .citationsEnabled(true)
@@ -67,7 +75,7 @@ public class AnthropicController {
             return new CitationsResponse("No response from Anthropic API", List.of());
         }
 
-        return new CitationsResponse(response.getResult().getOutput().getText(), extractCitations(response));
+        return new CitationsResponse(Optional.ofNullable(response.getResult()).map(Generation::getOutput).map(AssistantMessage::getText).orElse(null), extractCitations(response));
     }
 
     /**
@@ -76,11 +84,11 @@ public class AnthropicController {
      */
     @PostMapping("/skills/{type}")
     public SkillResponse generateDocument(@PathVariable String type, @RequestBody SkillRequest request) {
-        AnthropicApi.AnthropicSkill skill = switch (type.toLowerCase()) {
-            case "excel" -> AnthropicApi.AnthropicSkill.XLSX;
-            case "powerpoint" -> AnthropicApi.AnthropicSkill.PPTX;
-            case "word" -> AnthropicApi.AnthropicSkill.DOCX;
-            case "pdf" -> AnthropicApi.AnthropicSkill.PDF;
+        AnthropicSkill skill = switch (type.toLowerCase()) {
+            case "excel" -> AnthropicSkill.XLSX;
+            case "powerpoint" -> AnthropicSkill.PPTX;
+            case "word" -> AnthropicSkill.DOCX;
+            case "pdf" -> AnthropicSkill.PDF;
             default -> throw new IllegalArgumentException("Supported types: excel, powerpoint, word, pdf");
         };
 
@@ -90,23 +98,29 @@ public class AnthropicController {
                         AnthropicChatOptions.builder()
                                 .model("claude-sonnet-4-5")
                                 .maxTokens(16384)
-                                .anthropicSkill(skill)
+                                .skill(skill)
                                 .build()
                 )
         );
 
-        return new SkillResponse(response.getResult().getOutput().getText(), extractFileIds(response), type);
+        return new SkillResponse(Optional.ofNullable(response.getResult()).map(Generation::getOutput).map(AssistantMessage::getText).orElse(null), extractFileIds(response), type);
     }
 
     @GetMapping("/files/{fileId}")
-    public ResponseEntity<byte[]> downloadFile(@PathVariable String fileId) {
-        AnthropicApi.FileMetadata metadata = anthropicApi.getFileMetadata(fileId);
-        byte[] content = anthropicApi.downloadFile(fileId);
+    public ResponseEntity<byte[]> downloadFile(@PathVariable String fileId) throws IOException {
+        // Metadata retrieval
+        FileMetadata metadata = anthropicClient.beta().files()
+                .retrieveMetadata(FileRetrieveMetadataParams.builder().fileId(fileId).build());
 
-        return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"%s\"".formatted(metadata.filename()))
-                .contentType(MediaType.parseMediaType(metadata.mimeType()))
-                .body(content);
+        // Binary download — method is download(), not retrieveContent()
+        try (HttpResponse httpResponse = anthropicClient.beta().files().download(fileId)) {
+            byte[] content = httpResponse.body().readAllBytes();
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"%s\"".formatted(metadata.filename()))
+                    .contentType(MediaType.parseMediaType(metadata.mimeType()))
+                    .body(content);
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -116,7 +130,7 @@ public class AnthropicController {
     }
 
     private List<String> extractFileIds(ChatResponse response) {
-        return SkillsResponseHelper.extractFileIds(response);
+        return AnthropicSkillsResponseHelper.extractFileIds(response);
     }
 
     public record CitationRequest(String document, String title, String question) {

--- a/src/main/java/mb/oauth2authorizationserver/config/JacksonConfig.java
+++ b/src/main/java/mb/oauth2authorizationserver/config/JacksonConfig.java
@@ -1,0 +1,83 @@
+package mb.oauth2authorizationserver.config;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import mb.oauth2authorizationserver.config.security.model.HttpRequestDetails;
+import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.oauth2.server.authorization.jackson.OAuth2AuthorizationServerJacksonModule;
+import org.springframework.web.servlet.FlashMap;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.datatype.hibernate7.Hibernate7Module;
+
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.TimeZone;
+import java.util.TreeMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Central Jackson configuration.
+ * <p>
+ * Customizes the auto-configured {@link tools.jackson.databind.ObjectMapper} via
+ * {@link JsonMapperBuilderCustomizer}. The same settings are reused by the Redis
+ * cache serializer via {@link #applyCommonSettings(JsonMapper.Builder)}.
+ */
+@Configuration
+public class JacksonConfig {
+
+    /**
+     * Shared Jackson configuration applied to both the auto-configured
+     * {@link tools.jackson.databind.ObjectMapper} and the Redis cache
+     * serializer's internal mapper.
+     * <p>
+     * Does NOT include SecurityJacksonModules — they reset the
+     * {@link tools.jackson.databind.jsontype.PolymorphicTypeValidator} to
+     * {@code BasicPolymorphicTypeValidator} during {@code setupModule()}.
+     */
+    public static void applyCommonSettings(JsonMapper.Builder builder) {
+        builder.configure(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .configure(DateTimeFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false)
+                .configure(DateTimeFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false)
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+                .configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false)
+                .changeDefaultVisibility(vc -> vc.withVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY))
+                .changeDefaultPropertyInclusion(v -> v.withValueInclusion(JsonInclude.Include.NON_NULL))
+                .defaultTimeZone(TimeZone.getTimeZone(ZoneId.of("Europe/Istanbul")))
+                .addModules(new Hibernate7Module(), new OAuth2AuthorizationServerJacksonModule())
+                .addMixIn(Long.class, LongMixin.class)
+                .addMixIn(HttpRequestDetails.class, HttpRequestDetailsMixin.class)
+                .addMixIn(DisabledException.class, Object.class)
+                .addMixIn(Throwable.class, ThrowableMixin.class)
+                .addMixIn(CopyOnWriteArrayList.class, Object.class)
+                .addMixIn(ArrayList.class, Object.class)
+                .addMixIn(LinkedHashMap.class, Object.class)
+                .addMixIn(TreeMap.class, Object.class)
+                .addMixIn(FlashMap.class, Object.class);
+    }
+
+    @Bean
+    public JsonMapperBuilderCustomizer appJsonMapperBuilderCustomizer() {
+        return JacksonConfig::applyCommonSettings;
+    }
+
+    interface LongMixin {
+    }
+
+    interface HttpRequestDetailsMixin {
+    }
+
+    @JsonIgnoreProperties({"suppressed", "stackTrace", "localizedMessage", "cause"})
+    public static class ThrowableMixin {
+    }
+}

--- a/src/main/java/mb/oauth2authorizationserver/config/SessionConfig.java
+++ b/src/main/java/mb/oauth2authorizationserver/config/SessionConfig.java
@@ -1,95 +1,69 @@
 package mb.oauth2authorizationserver.config;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
-import mb.oauth2authorizationserver.config.security.model.HttpRequestDetails;
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.BeanClassLoaderAware;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
-import org.springframework.security.authentication.DisabledException;
-import org.springframework.security.jackson.SecurityJacksonModules;
-import org.springframework.security.oauth2.server.authorization.jackson.OAuth2AuthorizationServerJacksonModule;
 import org.springframework.session.FlushMode;
-import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisIndexedHttpSession;
 import org.springframework.session.web.context.AbstractHttpSessionApplicationInitializer;
-import tools.jackson.databind.DefaultTyping;
-import tools.jackson.databind.DeserializationFeature;
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.SerializationFeature;
-import tools.jackson.databind.cfg.DateTimeFeature;
-import tools.jackson.databind.json.JsonMapper;
-import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
-import tools.jackson.datatype.hibernate7.Hibernate7Module;
 
 import java.time.Duration;
-import java.time.ZoneId;
-import java.util.TimeZone;
 
 @EnableCaching
 @Configuration
-@ConditionalOnProperty(name = {"spring.data.redis.host"})
-@EnableRedisHttpSession(maxInactiveIntervalInSeconds = 3600, redisNamespace = "sso:session", flushMode = FlushMode.ON_SAVE)
+@EnableRedisIndexedHttpSession(maxInactiveIntervalInSeconds = 3600, redisNamespace = "sso:session", flushMode = FlushMode.ON_SAVE)
 public class SessionConfig extends AbstractHttpSessionApplicationInitializer implements BeanClassLoaderAware {
 
     private ClassLoader classLoader;
-
-    @Bean
-    public RedisSerializer<@NonNull Object> springSessionDefaultRedisSerializer() {
-        return new GenericJacksonJsonRedisSerializer(objectMapper());
-    }
 
     @Override
     public void setBeanClassLoader(@NonNull ClassLoader classLoader) {
         this.classLoader = classLoader;
     }
 
+    /**
+     * Spring Session serializer - uses Java serialization.
+     * <p>
+     * WHY NOT JACKSON: Jackson 3.x removed activateDefaultTyping() from ObjectMapper
+     * entirely (builder-only). SecurityJacksonModules resets the PolymorphicTypeValidator
+     * to BasicPolymorphicTypeValidator during setupModule(), and there is no post-build
+     * API in Jackson 3.x to override it. Java serialization is the correct tool here:
+     * all Spring Security types (Authentication, SecurityContext, OAuth2Authorization, etc.)
+     * implement Serializable by design, and this was Spring Session's default before
+     * JSON serialization became fashionable.
+     */
     @Bean
-    public RedisCacheManager redisCacheManagerBuilderCustomizer() {
-        return RedisCacheManager.builder().cacheDefaults(RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofDays(90))).build();
+    public RedisSerializer<@NonNull Object> springSessionDefaultRedisSerializer() {
+        // Uses the app classloader so Spring Security / OAuth2 types deserialize correctly
+        return RedisSerializer.java(this.classLoader);
     }
 
+    /**
+     * Cache manager - uses Jackson with the same settings as the primary
+     * {@link tools.jackson.databind.ObjectMapper} (see {@link JacksonConfig}), plus
+     * unsafe default typing for polymorphic cache-value resolution.
+     */
     @Bean
-    @Primary
-    public ObjectMapper objectMapper() {
-        return JsonMapper.builder()
-                .configure(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-                .configure(DateTimeFeature.WRITE_DURATIONS_AS_TIMESTAMPS, false)
-                .configure(DateTimeFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false)
-                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
-                .configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false)
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, false)
-                .changeDefaultVisibility(visibilityChecker -> visibilityChecker.withVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY))
-                .activateDefaultTyping(BasicPolymorphicTypeValidator.builder().build(), DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY)
-                .changeDefaultPropertyInclusion(value -> value.withValueInclusion(JsonInclude.Include.NON_NULL))
-                .defaultTimeZone(TimeZone.getTimeZone(ZoneId.of("Europe/Istanbul")))
-                .addModules(new Hibernate7Module(), new OAuth2AuthorizationServerJacksonModule())
-                .addModules(SecurityJacksonModules.getModules(this.classLoader))
-                .addMixIn(Long.class, LongMixin.class)
-                .addMixIn(HttpRequestDetails.class, HttpRequestDetailsMixin.class)
-                .addMixIn(DisabledException.class, Object.class)
-                .addMixIn(Throwable.class, ThrowableMixin.class)
+    public RedisCacheManager redisCacheManagerBuilderCustomizer(RedisConnectionFactory redisConnectionFactory) {
+        GenericJacksonJsonRedisSerializer jacksonSerializer = GenericJacksonJsonRedisSerializer.builder()
+                .enableUnsafeDefaultTyping()
+                .customize(JacksonConfig::applyCommonSettings)
                 .build();
-    }
 
-    interface LongMixin {
-    }
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofDays(90))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(jacksonSerializer));
 
-    interface HttpRequestDetailsMixin {
-    }
-
-    @JsonIgnoreProperties({"suppressed", "stackTrace", "localizedMessage", "cause"})
-    public static class ThrowableMixin {
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(config)
+                .build();
     }
 }

--- a/src/main/java/mb/oauth2authorizationserver/config/ai/OpenAIConfig.java
+++ b/src/main/java/mb/oauth2authorizationserver/config/ai/OpenAIConfig.java
@@ -1,5 +1,7 @@
 package mb.oauth2authorizationserver.config.ai;
 
+import com.anthropic.client.AnthropicClient;
+import com.anthropic.client.okhttp.AnthropicOkHttpClient;
 import com.google.genai.Client;
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
@@ -62,6 +64,13 @@ public class OpenAIConfig {
     @ConditionalOnBean(AnthropicChatModel.class)
     public ChatClient anthropicChatClient(AnthropicChatModel chatModel) {
         return ChatClient.builder(chatModel).build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(AnthropicChatModel.class)
+    public AnthropicClient anthropicClient(@Value("${spring.ai.anthropic.api-key}") String apiKey) {
+        return AnthropicOkHttpClient.builder().apiKey(apiKey).build();
     }
 
     @Bean

--- a/src/main/java/mb/oauth2authorizationserver/exception/RestResponseExceptionHandler.java
+++ b/src/main/java/mb/oauth2authorizationserver/exception/RestResponseExceptionHandler.java
@@ -2,15 +2,24 @@ package mb.oauth2authorizationserver.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @ControllerAdvice
 public class RestResponseExceptionHandler {
+
+    @ResponseBody
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFound(NoResourceFoundException ex) {
+        log.debug("Static resource not found: {}", ex.getMessage());
+        return new ResponseEntity<>(new LocalizedExceptionResponse(OAuth2AuthorizationServerServiceErrorCode.UNEXPECTED_ERROR.getCode(), ex.getMessage()), HttpStatus.NOT_FOUND);
+    }
 
     @ResponseBody
     @ExceptionHandler(BaseException.class)

--- a/src/main/java/mb/oauth2authorizationserver/service/ai/impl/VectorStoreServiceImpl.java
+++ b/src/main/java/mb/oauth2authorizationserver/service/ai/impl/VectorStoreServiceImpl.java
@@ -47,7 +47,7 @@ public class VectorStoreServiceImpl implements VectorStoreService {
     @Override
     public void loadPdf() {
         var pdfReader = new ParagraphPdfDocumentReader(marketPdf);
-        TextSplitter textSplitter = new TokenTextSplitter();
+        TextSplitter textSplitter = TokenTextSplitter.builder().build();
         vectorStore.accept(textSplitter.apply(pdfReader.get()));
         log.info("VectorStore loaded with PDF content");
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,11 @@ spring:
     password: ${DB_PASSWORD:test}
     driver-class-name: org.mariadb.jdbc.Driver
 
+  data:
+    redis:
+      host: ${SPRING_DATA_REDIS_HOST:localhost}
+      port: ${SPRING_DATA_REDIS_PORT:6379}
+
   flyway:
     enabled: true
     baseline-version: 0
@@ -73,10 +78,10 @@ spring:
     # NEW in 2.0: Redis Chat Memory configuration
     chat:
       memory:
-        repository:
-          redis:
-            key-prefix: "spring-ai-chat:"
-            time-to-live: 1h
+        redis:
+          key-prefix: "spring-ai-chat:"
+          time-to-live: 1h
+
     ollama:
       chat:
         model: deepseek-r1:7b
@@ -142,13 +147,13 @@ management:
   otlp:
     metrics:
       export:
-        url: http://localhost:4318/v1/metrics
+        url: ${OTEL_EXPORTER_OTLP_METRICS_URL:http://localhost:4318/v1/metrics}
   opentelemetry:
     tracing:
       export:
         otlp:
-          endpoint: http://localhost:4318/v1/traces
+          endpoint: ${OTEL_EXPORTER_OTLP_TRACES_URL:http://localhost:4318/v1/traces}
     logging:
       export:
         otlp:
-          endpoint: http://localhost:4318/v1/logs
+          endpoint: ${OTEL_EXPORTER_OTLP_LOGS_URL:http://localhost:4318/v1/logs}

--- a/src/test/java/mb/oauth2authorizationserver/api/controller/LoginControllerTest.java
+++ b/src/test/java/mb/oauth2authorizationserver/api/controller/LoginControllerTest.java
@@ -57,7 +57,7 @@ class LoginControllerTest {
         // Act
         // Assertions
         mockMvc.perform(get("/non-existent"))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -66,7 +66,7 @@ class LoginControllerTest {
         // Act
         // Assertions
         mockMvc.perform(get("/ott/invalid"))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isNotFound());
     }
 
     @Test

--- a/src/test/java/mb/oauth2authorizationserver/config/OracleCustomTestConfiguration.java
+++ b/src/test/java/mb/oauth2authorizationserver/config/OracleCustomTestConfiguration.java
@@ -1,0 +1,143 @@
+package mb.oauth2authorizationserver.config;
+
+import jakarta.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.oracle.OracleContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Generic test configuration class for Oracle database integration testing using Testcontainers.
+ *
+ * <p>This configuration starts an Oracle XE container and sets up system properties
+ * that can be used in test classes to configure Oracle datasources for any application.</p>
+ *
+ * <h3>Usage</h3>
+ * <p>To use this configuration in your test class, include it in the {@code @SpringBootTest} annotation
+ * and add the {@code @TestPropertySource} annotation to map the system properties to your specific datasource properties:</p>
+ *
+ * <h4>Example for custom datasource:</h4>
+ * <pre>{@code
+ * @TestPropertySource(properties = {
+ *         "custom.datasource.jdbc-url=${ORACLE_DATASOURCE_JDBC_URL}",
+ *         "custom.datasource.username=${ORACLE_DATASOURCE_USERNAME}",
+ *         "custom.datasource.password=${ORACLE_DATASOURCE_PASSWORD}",
+ * })
+ * @SpringBootTest(classes = {OracleIntegrationConfiguration.class, ...})
+ * class CustomIntegrationTest {
+ *     // Your test code
+ * }
+ * }</pre>
+ *
+ * <h4>Example for custom datasource:</h4>
+ * <pre>{@code
+ * @TestPropertySource(properties = {
+ *         "spring.datasource.url=${ORACLE_DATASOURCE_JDBC_URL}",
+ *         "spring.datasource.username=${ORACLE_DATASOURCE_USERNAME}",
+ *         "spring.datasource.password=${ORACLE_DATASOURCE_PASSWORD}",
+ *         "spring.datasource.driver-class-name=oracle.jdbc.OracleDriver"
+ * })
+ * @SpringBootTest(classes = {OracleIntegrationConfiguration.class, ...})
+ * class CustomIntegrationTest {
+ *     // Your test code
+ * }
+ * }</pre>
+ *
+ * <h4>Example for multiple datasources:</h4>
+ * <pre>{@code
+ * @TestPropertySource(properties = {
+ *         "primary.datasource.jdbc-url=${ORACLE_DATASOURCE_JDBC_URL}",
+ *         "primary.datasource.username=${ORACLE_DATASOURCE_USERNAME}",
+ *         "primary.datasource.password=${ORACLE_DATASOURCE_PASSWORD}",
+ *         "secondary.datasource.jdbc-url=${ORACLE_DATASOURCE_JDBC_URL}",
+ *         "secondary.datasource.username=${ORACLE_DATASOURCE_USERNAME}",
+ *         "secondary.datasource.password=${ORACLE_DATASOURCE_PASSWORD}",
+ * })
+ * @SpringBootTest(classes = {OracleIntegrationConfiguration.class, ...})
+ * class MultiDatasourceIntegrationTest {
+ *     // Your test code
+ * }
+ * }</pre>
+ * <h4>Example for application.yml:</h4>
+ * <pre>{@docRoot}/src/test/resources/application.yml
+ * spring:
+ *   datasource:
+ *     url: ${ORACLE_DATASOURCE_JDBC_URL}
+ *     username: ${ORACLE_DATASOURCE_USERNAME}
+ *     password: ${ORACLE_DATASOURCE_PASSWORD}
+ *     type: com.zaxxer.hikari.HikariDataSource
+ *     driver-class-name: oracle.jdbc.OracleDriver
+ * </pre>
+ */
+@Slf4j
+@TestConfiguration
+public class OracleCustomTestConfiguration {
+
+    @Container
+    public static final OracleContainer oracle = new OracleContainer(DockerImageName.parse("gvenzl/oracle-free:23-slim-faststart"))
+            .withExposedPorts(1521)
+            .withReuse(true);
+
+    public static class OracleInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        @Override
+        public void initialize(@Nonnull ConfigurableApplicationContext context) {
+            oracle.start();
+
+            String jdbcUrl = oracle.getJdbcUrl();
+            String username = oracle.getUsername();
+            String password = oracle.getPassword();
+
+            String oracleSchemaName = context.getEnvironment().getProperty("oracle-schema-name");
+            String namespace = context.getEnvironment().getProperty("namespace");
+
+            if (StringUtils.isNotBlank(oracleSchemaName) && StringUtils.isNotBlank(namespace)) {
+                String schemaUser = ("%s_%s".formatted(oracleSchemaName, namespace)).toUpperCase();
+                try (Connection connection = DriverManager.getConnection(jdbcUrl, "SYSTEM", password);
+                     Statement statement = connection.createStatement()) {
+                    boolean userExists;
+                    try (ResultSet resultSet = statement.executeQuery("SELECT 1 FROM ALL_USERS WHERE USERNAME = '%s'".formatted(schemaUser))) {
+                        userExists = resultSet.next();
+                    }
+                    if (!userExists) {
+                        statement.execute("CREATE USER %s IDENTIFIED BY %s QUOTA UNLIMITED ON USERS".formatted(schemaUser, password));
+                        statement.execute("GRANT CONNECT, RESOURCE, DBA TO %s".formatted(schemaUser));
+                    }
+                } catch (SQLException e) {
+                    log.warn("Failed to initialize Oracle test schema: {}, Exception: {}", schemaUser, ExceptionUtils.getStackTrace(e));
+                }
+
+                username = schemaUser;
+            }
+
+            System.setProperty("ORACLE_DATASOURCE_JDBC_URL", jdbcUrl);
+            System.setProperty("ORACLE_DATASOURCE_USERNAME", username);
+            System.setProperty("ORACLE_DATASOURCE_PASSWORD", password);
+
+            // Override Spring datasource & JPA properties so the context uses Oracle
+            // instead of the default MariaDB from test application.yml.
+            // Without this, Flyway-disabled tests fail on schema validation because
+            // Hibernate validates against an empty MariaDB that has no tables.
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+                    context,
+                    "spring.datasource.url=%s".formatted(jdbcUrl),
+                    "spring.datasource.username=%s".formatted(username),
+                    "spring.datasource.password=%s".formatted(password),
+                    "spring.datasource.driver-class-name=oracle.jdbc.OracleDriver",
+                    "spring.jpa.hibernate.ddl-auto=create-drop"
+            );
+        }
+    }
+}

--- a/src/test/java/mb/oauth2authorizationserver/config/RedisCustomTestConfiguration.java
+++ b/src/test/java/mb/oauth2authorizationserver/config/RedisCustomTestConfiguration.java
@@ -1,0 +1,42 @@
+package mb.oauth2authorizationserver.config;
+
+import com.redis.testcontainers.RedisContainer;
+import jakarta.annotation.Nonnull;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration
+public class RedisCustomTestConfiguration {
+
+    @Container
+    public static final RedisContainer redis = new RedisContainer(DockerImageName.parse("redis:8.4.0"))
+            .withExposedPorts(6379)
+            .withReuse(true);
+
+    public static class RedisInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+        @Override
+        public void initialize(@Nonnull ConfigurableApplicationContext context) {
+            redis.start();
+
+            String host = redis.getHost();
+            String port = String.valueOf(redis.getMappedPort(6379));
+
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+                    context,
+
+                    // Spring Boot 2.x
+                    "spring.redis.host=%s".formatted(host),
+                    "spring.redis.port=%s".formatted(port),
+
+                    // Spring Boot 3.x, 4.x
+                    "spring.data.redis.host=%s".formatted(host),
+                    "spring.data.redis.port=%s".formatted(port)
+            );
+        }
+    }
+}

--- a/src/test/java/mb/oauth2authorizationserver/config/RedisTestConfiguration.java
+++ b/src/test/java/mb/oauth2authorizationserver/config/RedisTestConfiguration.java
@@ -5,6 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.session.config.SessionRepositoryCustomizer;
+import org.springframework.session.data.redis.RedisIndexedSessionRepository;
 import org.testcontainers.utility.DockerImageName;
 
 @Slf4j
@@ -24,5 +27,16 @@ public class RedisTestConfiguration {
         log.info("Redis server started. isCreated: {}, isRunning: {}", redisContainer.isCreated(), redisContainer.isRunning());
 
         return redisContainer;
+    }
+
+    /**
+     * Disables the per-minute session cleanup scheduler during tests.
+     * Without this, the scheduler fires during context shutdown after
+     * LettuceConnectionFactory has already been stopped, causing
+     * IllegalStateException: LettuceConnectionFactory has been STOPPED.
+     */
+    @Bean
+    public SessionRepositoryCustomizer<RedisIndexedSessionRepository> disableCleanupCron() {
+        return repository -> repository.setCleanupCron(Scheduled.CRON_DISABLED);
     }
 }

--- a/src/test/java/mb/oauth2authorizationserver/config/TestSecurityConfig.java
+++ b/src/test/java/mb/oauth2authorizationserver/config/TestSecurityConfig.java
@@ -1,40 +1,31 @@
 package mb.oauth2authorizationserver.config;
 
-import com.nimbusds.jose.jwk.source.JWKSource;
-import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.core.session.SessionRegistry;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 
+/**
+ * Test security configuration that disables all Spring Security filters.
+ * <p>
+ * Does NOT re-declare {@code jwtDecoder}, {@code jwkSource}, or {@code sessionRegistry} —
+ * those are provided by the real {@code SecurityConfig} and work without Redis or external keys.
+ * {@code FindByIndexNameSessionRepository} is provided by {@code RedisTestConfiguration}.
+ */
 @TestConfiguration
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = false)
 public class TestSecurityConfig {
 
+    /**
+     * Disables all Spring Security filters so controller tests run without authentication.
+     *
+     * @return a customizer that ignores all request paths
+     */
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring().requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/**"));
-    }
-
-    @Bean
-    @Primary
-    public JwtDecoder jwtDecoder() {
-        return Mockito.mock(JwtDecoder.class);
-    }
-
-    @Bean
-    public JWKSource<?> jwkSource() {
-        return Mockito.mock(JWKSource.class);
-    }
-
-    @Bean
-    public SessionRegistry sessionRegistry() {
-        return Mockito.mock(SessionRegistry.class);
     }
 }

--- a/src/test/java/mb/oauth2authorizationserver/config/ai/McpClientStdio.java
+++ b/src/test/java/mb/oauth2authorizationserver/config/ai/McpClientStdio.java
@@ -1,10 +1,10 @@
 package mb.oauth2authorizationserver.config.ai;
 
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
-import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import mb.oauth2authorizationserver.utils.FileUtils;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * With stdio transport, the MCP server is automatically started by the client. Server jar should be built first.

--- a/src/test/java/mb/oauth2authorizationserver/data/repository/AuthorityRepositoryCustomTest.java
+++ b/src/test/java/mb/oauth2authorizationserver/data/repository/AuthorityRepositoryCustomTest.java
@@ -1,0 +1,57 @@
+package mb.oauth2authorizationserver.data.repository;
+
+import mb.oauth2authorizationserver.config.OracleCustomTestConfiguration;
+import mb.oauth2authorizationserver.config.RedisCustomTestConfiguration;
+import mb.oauth2authorizationserver.data.entity.Authority;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestPropertySource(
+        properties = {
+                "oracle-schema-name=oauth2",
+                "spring.flyway.enabled=false",
+                "namespace=authorization_server"
+        })
+@ContextConfiguration(
+        initializers = {
+                RedisCustomTestConfiguration.RedisInitializer.class,
+                OracleCustomTestConfiguration.OracleInitializer.class
+        }
+)
+class AuthorityRepositoryCustomTest {
+
+    @Autowired
+    private AuthorityRepository authorityRepository;
+
+    @BeforeAll
+    void setUp() {
+        authorityRepository.saveAll(
+                Instancio.ofList(Authority.class)
+                        .size(10)
+                        .supply(field(Authority::getId), () -> null)  // 👈 ensure ID is null
+                        .create()
+        );
+    }
+
+    @Test
+    void findAll_ShouldReturnTenAuthorities_WhenPersisted() {
+        assertThat(authorityRepository.findAll())
+                .hasSize(10)
+                .allSatisfy(authority -> {
+                            assertThat(authority.getId()).isNotNull();
+                            assertThat(authority.getAuthority()).isNotBlank();
+                        }
+                );
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,14 +2,13 @@ server:
   port: '9000'
 
 spring:
-  main:
-    allow-bean-definition-overriding: true
-
   datasource:
     url: 'jdbc:tc:mariadb:12.1.2://localhost:3306/oauth2_authorization_server'
     username: mb_test
     password: 'test'
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    hikari:
+      minimum-idle: 0 # Prevent HikariPool from refilling connections during shutdown (avoids Testcontainers race condition with HikariCheckpointRestoreLifecycle)
 
   flyway:
     enabled: true
@@ -66,10 +65,9 @@ spring:
     # NEW in 2.0: Redis Chat Memory configuration
     chat:
       memory:
-        repository:
-          redis:
-            key-prefix: "spring-ai-chat:"
-            time-to-live: 1h
+        redis:
+          key-prefix: "spring-ai-chat:"
+          time-to-live: 1h
 
 logging:
   level:


### PR DESCRIPTION
refactor: extract Jackson config, simplify Redis session, fix Swagger versions and Dockerfile

- Extract shared Jackson settings into JacksonConfig with JsonMapperBuilderCustomizer
- Simplify SessionConfig: use GenericJacksonJsonRedisSerializer, Java serialization for sessions
- Remove custom AllowAllTypeValidator and Jackson3RedisSerializer
- Align Swagger artifacts to 2.2.47 via BOM (fix NoSuchMethodError on $dynamicRef)
- Multi-stage Dockerfile with jlink custom JRE and Spring Boot layer extraction
- Add application service profile to docker-compose
- Handle NoResourceFoundException gracefully (debug-level log, 404 response)