### PR TITLE
add Redisson distributed lock to prevent duplicate tokens on concurrent login

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,14 @@ services:
       SPRING_AI_OLLAMA_BASE_URL: http://ollama:11434
       SPRING_AI_OLLAMA_INIT_PULL_MODEL_STRATEGY: never
     depends_on:
-      - mariadb
-      - redis
-      - lldap
-      - ollama
+      mariadb:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      lldap:
+        condition: service_started
+      ollama:
+        condition: service_started
     restart: unless-stopped
     networks:
       - oauth2-network
@@ -46,6 +50,12 @@ services:
       - data:/var/lib/mysql
     ports:
       - "3306:3306"
+    healthcheck:
+      test: [ "CMD", "healthcheck.sh", "--connect", "--innodb_initialized" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
     networks:
       - oauth2-network
@@ -144,7 +154,7 @@ services:
       - oauth2-network
 
   grafana-lgtm:
-    image: 'grafana/otel-lgtm:0.13.0'
+    image: 'grafana/otel-lgtm:0.27.1'
     ports:
       - "3001:3000"   # Grafana UI
       - "4318:4318"   # OTLP HTTP receiver

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <properties>
         <java.version>25</java.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
+        <redisson-spring-boot-starter.version>4.3.1</redisson-spring-boot-starter.version>
         <thymeleaf-extras-springsecurity6.version>3.1.5.RELEASE</thymeleaf-extras-springsecurity6.version>
         <mariadb-java-client.version>3.5.8</mariadb-java-client.version>
         <ojdbc17.version>23.26.1.0.0</ojdbc17.version>
@@ -161,6 +162,12 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson-spring-boot-starter</artifactId>
+            <version>${redisson-spring-boot-starter.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/mb/oauth2authorizationserver/config/security/SecurityConfig.java
+++ b/src/main/java/mb/oauth2authorizationserver/config/security/SecurityConfig.java
@@ -29,6 +29,7 @@ import mb.oauth2authorizationserver.data.repository.AuthorizationRepository;
 import mb.oauth2authorizationserver.data.repository.UserRepository;
 import mb.oauth2authorizationserver.utils.SecurityUtils;
 import org.jspecify.annotations.NonNull;
+import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -187,8 +188,9 @@ public class SecurityConfig {
                                                      @Qualifier("customAccessDeniedHandler") AccessDeniedHandler accessDeniedHandler,
                                                      TokenService tokenService,
                                                      UserLoginAttemptService userLoginAttemptService,
-                                                     CustomAuthenticationService customAuthenticationService) {
-        OAuth2AuthorizationService oAuth2AuthorizationService = new OAuth2AuthorizationServiceImpl(authorizationRepository, authorizationBuilderService);
+                                                     CustomAuthenticationService customAuthenticationService,
+                                                     RedissonClient redissonClient) {
+        OAuth2AuthorizationService oAuth2AuthorizationService = new OAuth2AuthorizationServiceImpl(authorizationRepository, authorizationBuilderService, redissonClient);
         OAuth2AuthorizationServerConfigurer authorizationServerConfigurer = new OAuth2AuthorizationServerConfigurer();
 
         httpSecurity

--- a/src/main/java/mb/oauth2authorizationserver/config/security/converter/CustomPasswordAuthenticationConverter.java
+++ b/src/main/java/mb/oauth2authorizationserver/config/security/converter/CustomPasswordAuthenticationConverter.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 public class CustomPasswordAuthenticationConverter implements AuthenticationConverter {
 
-    private static final List<String> ALLOWED_GRANT_TYPES = List.of("password", "custom_password");
+    private static final List<String> ALLOWED_GRANT_TYPES = List.of(ServiceConstants.PASSWORD, ServiceConstants.CUSTOM_PASSWORD);
 
     @Nullable
     @Override

--- a/src/main/java/mb/oauth2authorizationserver/config/security/provider/CustomPasswordAuthenticationProvider.java
+++ b/src/main/java/mb/oauth2authorizationserver/config/security/provider/CustomPasswordAuthenticationProvider.java
@@ -150,7 +150,7 @@ public class CustomPasswordAuthenticationProvider implements AuthenticationProvi
 
                     OAuth2Authorization.Builder authorizationBuilder = OAuth2Authorization.withRegisteredClient(registeredClient)
                             .attribute(Principal.class.getName(), clientPrincipal)
-                            .principalName(clientPrincipal.getName())
+                            .principalName(username)
                             .authorizationGrantType(new AuthorizationGrantType(ServiceConstants.CUSTOM_PASSWORD))
                             .authorizedScopes(authorizedScopes);
 

--- a/src/main/java/mb/oauth2authorizationserver/config/security/service/impl/OAuth2AuthorizationServiceImpl.java
+++ b/src/main/java/mb/oauth2authorizationserver/config/security/service/impl/OAuth2AuthorizationServiceImpl.java
@@ -1,34 +1,78 @@
 package mb.oauth2authorizationserver.config.security.service.impl;
 
+import lombok.extern.slf4j.Slf4j;
 import mb.oauth2authorizationserver.config.security.builder.AuthorizationBuilderService;
+import mb.oauth2authorizationserver.constants.ServiceConstants;
 import mb.oauth2authorizationserver.data.entity.Authorization;
 import mb.oauth2authorizationserver.data.repository.AuthorizationRepository;
 import org.jspecify.annotations.Nullable;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 public class OAuth2AuthorizationServiceImpl implements OAuth2AuthorizationService {
 
     private final AuthorizationRepository authorizationRepository;
     private final AuthorizationBuilderService authorizationBuilderService;
+    private final RedissonClient redissonClient;
 
-    public OAuth2AuthorizationServiceImpl(AuthorizationRepository authorizationRepository, AuthorizationBuilderService authorizationBuilderService) {
+    public OAuth2AuthorizationServiceImpl(AuthorizationRepository authorizationRepository, AuthorizationBuilderService authorizationBuilderService, RedissonClient redissonClient) {
         Assert.notNull(authorizationRepository, "authorizationRepository cannot be null");
         this.authorizationRepository = authorizationRepository;
         this.authorizationBuilderService = authorizationBuilderService;
+        this.redissonClient = redissonClient;
     }
 
     @Override
+    @Transactional
     public void save(OAuth2Authorization authorization) {
         Assert.notNull(authorization, "authorization cannot be null");
-        this.authorizationRepository.save(authorizationBuilderService.toEntity(authorization));
+
+        Authorization newEntity = authorizationBuilderService.toEntity(authorization);
+        AuthorizationGrantType authorizationGrantType = authorization.getAuthorizationGrantType();
+
+        // Acquire distributed lock to prevent duplicate tokens during concurrent requests
+        String lockKey = String.format(ServiceConstants.AUTHORIZATION_LOCK, authorization.getRegisteredClientId(), newEntity.getPrincipalName(), authorizationGrantType.getValue());
+
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            if (!lock.tryLock(5, 10, TimeUnit.SECONDS)) {
+                log.warn("Could not acquire distributed lock within timeout, skipping token save to prevent duplicate. clientId: {}, principalName: {}, grantType: {}", authorization.getRegisteredClientId(), newEntity.getPrincipalName(), authorizationGrantType.getValue());
+                return;
+            }
+
+            Optional<Authorization> optionalExistingAuthorization = AuthorizationGrantType.AUTHORIZATION_CODE.equals(authorizationGrantType)
+                    ? authorizationRepository.findByAuthorizationCodeValue(newEntity.getAuthorizationCodeValue())
+                    : authorizationRepository.findByRegisteredClientIdAndPrincipalNameAndAuthorizationGrantType(authorization.getRegisteredClientId(), newEntity.getPrincipalName(), authorizationGrantType.getValue());
+
+            optionalExistingAuthorization.ifPresentOrElse(existingAuthorization -> {
+                        newEntity.setId(existingAuthorization.getId());
+                        authorizationRepository.save(newEntity);
+                    },
+                    () -> authorizationRepository.save(newEntity)
+            );
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while acquiring distributed lock. lockKey: {}", lockKey, e);
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
     }
 
     @Override
@@ -46,12 +90,14 @@ public class OAuth2AuthorizationServiceImpl implements OAuth2AuthorizationServic
 
     @Nullable
     @Override
+    @Transactional
     public OAuth2Authorization findByToken(String token, @Nullable OAuth2TokenType tokenType) {
         Assert.hasText(token, "token cannot be empty");
 
         Optional<Authorization> result;
-        if (tokenType == null) {
-            result = this.authorizationRepository.findByStateOrAuthorizationCodeValueOrAccessTokenValueOrRefreshTokenValue(token);
+
+        if (Objects.isNull(tokenType)) {
+            result = this.authorizationRepository.findByAccessTokenValue(token).or(() -> authorizationRepository.findByStateOrAuthorizationCodeValueOrAccessTokenValueOrRefreshTokenValue(token));
         } else if (OAuth2ParameterNames.STATE.equals(tokenType.getValue())) {
             result = this.authorizationRepository.findByState(token);
         } else if (OAuth2ParameterNames.CODE.equals(tokenType.getValue())) {
@@ -64,6 +110,20 @@ public class OAuth2AuthorizationServiceImpl implements OAuth2AuthorizationServic
             result = Optional.empty();
         }
 
-        return result.map(authorizationBuilderService::toObject).orElse(null);
+        return result.map(authorization -> {
+            boolean isRefreshTokenLookup = tokenType != null && OAuth2ParameterNames.REFRESH_TOKEN.equals(tokenType.getValue());
+            if (isRefreshTokenLookup) {
+                if (authorization.isRefreshTokenExpired()) {
+                    log.debug("Found expired refresh token for user '{}', removing from database", authorization.getPrincipalName());
+                    authorizationRepository.delete(authorization);
+                    return null;
+                }
+            } else if (authorization.isExpired()) {
+                log.debug("Found expired token for user '{}', removing from database", authorization.getPrincipalName());
+                authorizationRepository.delete(authorization);
+                return null;
+            }
+            return authorizationBuilderService.toObject(authorization);
+        }).orElse(null);
     }
 }

--- a/src/main/java/mb/oauth2authorizationserver/constants/ServiceConstants.java
+++ b/src/main/java/mb/oauth2authorizationserver/constants/ServiceConstants.java
@@ -40,10 +40,12 @@ public final class ServiceConstants {
     public static final String ADD_USER = "add-user";
 
     public static final String ACCESS_TOKEN_COOKIE_NAME = "st";
-    public static final String CUSTOM_PASSWORD = "password";
+    public static final String CUSTOM_PASSWORD = "custom_password";
 
     public static final String CLIENT_SAVED = "Client saved";
     public static final String CLIENT_UPDATED = "Client updated";
     public static final String USER_SAVED = "User saved";
     public static final String USER_UPDATED = "User updated";
+
+    public static final String AUTHORIZATION_LOCK = "oauth2-authorization-server:authorizationLock:%s:%s:%s";
 }

--- a/src/main/java/mb/oauth2authorizationserver/data/entity/Authorization.java
+++ b/src/main/java/mb/oauth2authorizationserver/data/entity/Authorization.java
@@ -10,6 +10,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
+import java.util.Objects;
 
 @Data
 @Entity
@@ -79,4 +80,12 @@ public class Authorization {
     @Lob
     @Column(length = 2000)
     private String oidcIdTokenClaims;
+
+    public boolean isExpired() {
+        return Objects.nonNull(accessTokenExpiresAt) && Instant.now().isAfter(accessTokenExpiresAt);
+    }
+
+    public boolean isRefreshTokenExpired() {
+        return Objects.nonNull(refreshTokenExpiresAt) && Instant.now().isAfter(refreshTokenExpiresAt);
+    }
 }

--- a/src/test/java/mb/oauth2authorizationserver/CustomPasswordTest.java
+++ b/src/test/java/mb/oauth2authorizationserver/CustomPasswordTest.java
@@ -35,7 +35,7 @@ class CustomPasswordTest extends BaseUnitTest {
         log.info("Start exchangeAccessTokenUsingCustomPassword test");
 
         MvcResult mvcResult = this.mvc.perform(post(DEFAULT_TOKEN_ENDPOINT_URI)
-                        .param(OAuth2ParameterNames.GRANT_TYPE, new AuthorizationGrantType("custom_password").getValue())
+                        .param(OAuth2ParameterNames.GRANT_TYPE, new AuthorizationGrantType(ServiceConstants.CUSTOM_PASSWORD).getValue())
                         .param(ServiceConstants.USERNAME, "User")
                         .param(ServiceConstants.PASSWORD, "password")
                         .header(HttpHeaders.AUTHORIZATION, "Basic " + encodeBasicAuth("client", "secret")))

--- a/src/test/java/mb/oauth2authorizationserver/OAuth2AuthenticationFlowIntegrationTest.java
+++ b/src/test/java/mb/oauth2authorizationserver/OAuth2AuthenticationFlowIntegrationTest.java
@@ -2,6 +2,8 @@ package mb.oauth2authorizationserver;
 
 import lombok.extern.slf4j.Slf4j;
 import mb.oauth2authorizationserver.config.RedisTestConfiguration;
+import mb.oauth2authorizationserver.constants.ServiceConstants;
+import mb.oauth2authorizationserver.data.repository.AuthorizationRepository;
 import mb.oauth2authorizationserver.data.repository.ClientRepository;
 import mb.oauth2authorizationserver.model.enums.GrantType;
 import org.apache.commons.lang3.StringUtils;
@@ -20,14 +22,19 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.security.MessageDigest;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -35,7 +42,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Slf4j
-@Transactional
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = RedisTestConfiguration.class)
 class OAuth2AuthenticationFlowIntegrationTest {
@@ -57,6 +63,9 @@ class OAuth2AuthenticationFlowIntegrationTest {
 
     @Autowired
     private JwtDecoder jwtDecoder;
+
+    @Autowired
+    private AuthorizationRepository authorizationRepository;
 
     @Test
     void getGrantTypeClientCredentialsToken_ShouldSucceed_WhenClientIsValid() throws Exception {
@@ -93,6 +102,48 @@ class OAuth2AuthenticationFlowIntegrationTest {
     @Test
     void getGrantTypePasswordToken_ShouldSucceed_WhenUsernameAndPasswordAreValid() throws Exception {
         Assertions.assertNotNull(generateAndValidateGrantTypePasswordTokenAndGetJsonObjectWhenUsernameAndPasswordAreValid());
+    }
+
+    @Test
+    void getGrantTypePasswordToken_ShouldNotCreateDuplicateTokens_WhenConcurrentRequestsAreSent() throws Exception {
+        // Arrange — clear any existing tokens for this user
+        authorizationRepository.deleteAll(authorizationRepository.findByPrincipalName(USER));
+
+        int concurrentRequests = 5;
+        try (ExecutorService executor = Executors.newFixedThreadPool(concurrentRequests)) {
+            CountDownLatch startLatch = new CountDownLatch(1);
+            List<Future<Integer>> futures = new ArrayList<>();
+
+            // Act — send concurrent password grant requests simultaneously
+            for (int i = 0; i < concurrentRequests; i++) {
+                futures.add(executor.submit(() -> {
+                    startLatch.await(); // wait until all threads are ready
+                    return mockMvc.perform(MockMvcRequestBuilders.post("/oauth2/token")
+                                    .param("grant_type", ServiceConstants.CUSTOM_PASSWORD)
+                                    .param("username", USER)
+                                    .param("password", PASSWORD)
+                                    .header("Authorization", generateBasicAuthHeader()))
+                            .andReturn()
+                            .getResponse()
+                            .getStatus();
+                }));
+            }
+            startLatch.countDown(); // release all threads at once
+
+            // Wait for all requests to complete
+            for (Future<Integer> future : futures) {
+                int status = future.get();
+                assertEquals(200, status, "All concurrent login requests should succeed");
+            }
+        }
+
+        // Assertions — count tokens in database for this user with custom_password grant type
+        long tokenCount = authorizationRepository.findByPrincipalName(USER)
+                .stream()
+                .filter(token -> ServiceConstants.CUSTOM_PASSWORD.equals(token.getAuthorizationGrantType()))
+                .count();
+
+        assertEquals(1, tokenCount, "There should be exactly 1 token — no duplicates");
     }
 
     @Test
@@ -261,7 +312,7 @@ class OAuth2AuthenticationFlowIntegrationTest {
         // Arrange
         // Act
         String response = mockMvc.perform(MockMvcRequestBuilders.post("/oauth2/token")
-                        .param("grant_type", "custom_password")
+                        .param("grant_type", ServiceConstants.CUSTOM_PASSWORD)
                         .param("username", USER)
                         .param("password", PASSWORD)
                         .header("Authorization", generateBasicAuthHeader()))

--- a/src/test/java/mb/oauth2authorizationserver/config/security/provider/CustomPasswordAuthenticationProviderTest.java
+++ b/src/test/java/mb/oauth2authorizationserver/config/security/provider/CustomPasswordAuthenticationProviderTest.java
@@ -6,6 +6,7 @@ import mb.oauth2authorizationserver.config.security.service.CustomAuthentication
 import mb.oauth2authorizationserver.config.security.service.TokenService;
 import mb.oauth2authorizationserver.config.security.service.UserLoginAttemptService;
 import mb.oauth2authorizationserver.constants.ErrorMessageConstants;
+import mb.oauth2authorizationserver.constants.ServiceConstants;
 import mb.oauth2authorizationserver.data.entity.Authority;
 import mb.oauth2authorizationserver.data.entity.SecurityUser;
 import org.junit.jupiter.api.AfterEach;
@@ -101,7 +102,7 @@ class CustomPasswordAuthenticationProviderTest {
         RegisteredClient registeredClient = RegisteredClient.withId("test-client-id")
                 .clientId("test-client")
                 .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
-                .authorizationGrantType(new AuthorizationGrantType("custom_password"))
+                .authorizationGrantType(new AuthorizationGrantType(ServiceConstants.CUSTOM_PASSWORD))
                 .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
                 .scope("read")
                 .scope("write")
@@ -308,7 +309,7 @@ class CustomPasswordAuthenticationProviderTest {
         RegisteredClient clientWithoutRefreshToken = RegisteredClient.withId("test-client-id")
                 .clientId("test-client")
                 .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
-                .authorizationGrantType(new AuthorizationGrantType("custom_password"))
+                .authorizationGrantType(new AuthorizationGrantType(ServiceConstants.CUSTOM_PASSWORD))
                 .scope("read")
                 .tokenSettings(TokenSettings.builder()
                         .accessTokenTimeToLive(Duration.ofHours(1))
@@ -346,7 +347,7 @@ class CustomPasswordAuthenticationProviderTest {
         RegisteredClient clientWithNoneAuth = RegisteredClient.withId("test-client-id")
                 .clientId("test-client")
                 .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
-                .authorizationGrantType(new AuthorizationGrantType("custom_password"))
+                .authorizationGrantType(new AuthorizationGrantType(ServiceConstants.CUSTOM_PASSWORD))
                 .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
                 .scope("read")
                 .tokenSettings(TokenSettings.builder()


### PR DESCRIPTION
add Redisson distributed lock to prevent duplicate tokens on concurrent login

- Add Redisson dependency and configuration for distributed locking
- Wrap OAuth2AuthorizationServiceImpl.save() with tryLock to serialize concurrent token creation
- Reuse existing authorization ID instead of inserting duplicates
- Store username as principalName instead of client ID in custom_password grant
- Remove @Transactional from integration test to fix concurrent thread isolation
- Fix test assertion to query by correct principalName